### PR TITLE
Feat: Adjust player counts and refine real-time updates

### DIFF
--- a/hooks/use-multiplayer.ts
+++ b/hooks/use-multiplayer.ts
@@ -273,8 +273,9 @@ export function useMultiplayer(roomCode: string, playerName: string, isAdmin: bo
   const startGame = useCallback(async () => {
     if (!room || !isConnected) return false
 
-    // Need at least 3 players
-    if (room.players.length < 3) {
+    // Need at least 2 players (new requirement)
+    if (room.players.length < 2) {
+      setError("At least 2 players are required to start the game."); // Also set error for more feedback
       return false
     }
 

--- a/lib/game-store.ts
+++ b/lib/game-store.ts
@@ -249,8 +249,8 @@ export class GameStore {
         .insert({
           id: upperRoomCode,
           settings: {
-            totalPlayers: 6,
-            imposterCount: 2,
+            totalPlayers: 4, // Updated default
+            imposterCount: 1, // Sensible default for 4 players
             difficulty: "easy",
             roundTime: 10,
           },
@@ -703,8 +703,8 @@ export class GameStore {
         },
       ],
       settings: {
-        totalPlayers: 6,
-        imposterCount: 2,
+        totalPlayers: 4, // Updated default
+        imposterCount: 1, // Sensible default for 4 players
         difficulty: "easy",
         roundTime: 10,
       },


### PR DESCRIPTION
- Verified and improved logging for real-time player list updates.
- Adjusted minimum players to start game to 2 (from 3).
  - Updated game start logic in `useMultiplayer.ts`.
  - Updated UI disabled states and informational text in `game-room.tsx`.
- Updated game settings UI for player count:
  - 'Total Players' Select now allows 2-20 players.
  - Default total players for new rooms is now 4 (1 imposter).
- Adapted imposter assignment UI:
  - 'Imposters' Select in `game-room.tsx` now dynamically shows valid options (1 to floor(totalPlayers/2)).
  - Added `useEffect` to auto-correct selected imposter count if totalPlayers changes, ensuring settings remain valid.
- Conceptually tested new player count scenarios; core logic adapts well. Noted a pre-existing general issue: game may stall if voting phase timer expires without all players voting (no forced tally).